### PR TITLE
Add IsNotEmpty on password to user DTO and handle unauthorized exception in auth service

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,9 +1,4 @@
-import {
-  HttpException,
-  HttpStatus,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectModel } from '@nestjs/sequelize';
 import { User } from 'src/users/user.model';

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -7,4 +7,5 @@ export class UpdateUserDto extends PartialType(UserDto) {
   photo?: string;
   email?: string;
   isAdmin?: boolean;
+  password?: string;
 }

--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -20,9 +20,11 @@ export class UserDto {
   photo: string;
 
   @IsEmail()
+  @IsNotEmpty()
   email: string;
 
   @IsString()
+  @IsNotEmpty()
   @MinLength(4)
   @MaxLength(20)
   @Matches(/((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {


### PR DESCRIPTION
This pull request adds the `IsNotEmpty` decorator to the `password` field in the `UserDto` class to ensure it is not empty. It also handles the `UnauthorizedException` in the `AuthService` class when the password is incorrect.

After some research, I saw that saving the jwt in the database is not a good practice so I just made a few refactor on the auth module but nothing more.