### PR TITLE
Update bump-version.yml workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,21 +11,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 'Checkout source code'
-        uses: 'actions/checkout@v2'
-        with:
-          ref: ${{ github.ref }}
-      - name: 'cat package.json'
-        run: cat ./package.json
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@v1'
-        with:
-          node-version: 20
-      - name: 'Automated Version Bump'
-        uses: 'phips28/gh-action-bump-version@master'
-        with:
-          tag-prefix: ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'cat package.json'
-        run: cat ./package.json
+      - name: Automated Version Bump
+        uses: phips28/gh-action-bump-version@v11.0.4


### PR DESCRIPTION
This pull request updates the bump-version.yml workflow to use version 11.0.4 of the phips28/gh-action-bump-version action.