### PR TITLE
Add automated version bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,5 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: 'Checkout source code'
+        uses: 'actions/checkout@v2'
+        with:
+          ref: ${{ github.ref }}
+      - name: 'cat package.json'
+        run: cat ./package.json
       - name: Automated Version Bump
         uses: phips28/gh-action-bump-version@v11.0.4
+        with:
+          tag-prefix: 'v'


### PR DESCRIPTION
This pull request adds an automated version bump workflow to the project. The workflow uses the `phips28/gh-action-bump-version` action to bump the version in the `package.json` file. This will help streamline the versioning process and ensure consistent versioning across the project.