### PR TITLE
Add permissions and environment variables to bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,8 +19,15 @@ jobs:
       - name: 'cat package.json'
         run: cat ./package.json
       - name: Automated Version Bump
+        id: version-bump
         uses: phips28/gh-action-bump-version@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag-prefix: 'v'
+      - name: 'cat package.json'
+        run: cat ./package.json
+      - name: 'Output Step'
+        env:
+          NEW_TAG: ${{ steps.version-bump.outputs.newTag }}
+        run: echo "new tag $NEW_TAG"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -9,7 +9,8 @@ jobs:
   bump-version:
     name: 'Bump Version on master'
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - name: 'Checkout source code'
         uses: 'actions/checkout@v2'
@@ -18,6 +19,8 @@ jobs:
       - name: 'cat package.json'
         run: cat ./package.json
       - name: Automated Version Bump
-        uses: phips28/gh-action-bump-version@v11.0.4
+        uses: phips28/gh-action-bump-version@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag-prefix: 'v'


### PR DESCRIPTION
This pull request adds permissions and environment variables to the bump-version workflow. It ensures that the workflow has write access to the contents and includes the necessary environment variables for the workflow to function properly.